### PR TITLE
fix/bug: update events related to react 18

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ export const App: React.FC = () => {
     } else {
       setPosts([]);
     }
-  }, [author?.id]);
+  }, [author]);
 
   return (
     <main className="section">

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -53,7 +53,8 @@ export const UserSelector: React.FC<Props> = ({
           className="button"
           aria-haspopup="true"
           aria-controls="dropdown-menu"
-          onClick={() => {
+          onClick={(e) => {
+            e.stopPropagation();
             setExpanded(current => !current);
           }}
         >


### PR DESCRIPTION
## Issue
- The click event propagates to the document, triggering the handleDocumentClick function  2 times

## Solution
- Add `stopPropagation` to prevent the event from reaching the document level and triggering the handleDocumentClick function.
- Update `App.tsx` `useEffect` deps to avoid warning
