### PR TITLE
solution 0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Learn the implemented App and the example and reimplement it with Redux having t
 - Implement a solution following the [React task guideline](https://github.com/mate-academy/react_task-guideline#react-tasks-guideline).
 - Use the [React TypeScript cheat sheet](https://mate-academy.github.io/fe-program/js/extra/react-typescript).
 - This task does not have tests yet!
-- Replace `<your_account>` with your Github username in the [DEMO LINK](https://<your_account>.github.io/react_redux-list-of-posts/) and add it to the PR description.
+- Replace `<your_account>` with your Github username in the [DEMO LINK](https://StanislavKapytsia.github.io/react_redux-list-of-posts/) and add it to the PR description.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import classNames from 'classnames';
 
 import 'bulma/css/bulma.css';
@@ -9,39 +9,35 @@ import { PostsList } from './components/PostsList';
 import { PostDetails } from './components/PostDetails';
 import { UserSelector } from './components/UserSelector';
 import { Loader } from './components/Loader';
-import { getUserPosts } from './api/posts';
-import { User } from './types/User';
-import { Post } from './types/Post';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from './app/store';
+import { cleanPosts, setPosts } from './features/posts';
+import { cleanPost } from './features/selectedPost';
 
 export const App: React.FC = () => {
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loaded, setLoaded] = useState(false);
-  const [hasError, setError] = useState(false);
+  const { loaded, hasError, posts } = useSelector(
+    (state: RootState) => state.posts,
+  );
 
-  const [author, setAuthor] = useState<User | null>(null);
-  const [selectedPost, setSelectedPost] = useState<Post | null>(null);
+  const dispatch: AppDispatch = useDispatch();
 
-  function loadUserPosts(userId: number) {
-    setLoaded(false);
+  const author = useSelector((state: RootState) => state.user);
+  const selectedPost = useSelector((state: RootState) => state.post);
 
-    getUserPosts(userId)
-      .then(setPosts)
-      .catch(() => setError(true))
-      // We disable the spinner in any case
-      .finally(() => setLoaded(true));
-  }
+  // const [selectedPost, setSelectedPost] = useState<Post | null>(null);
 
   useEffect(() => {
     // we clear the post when an author is changed
     // not to confuse the user
-    setSelectedPost(null);
+    // setSelectedPost(null);
+    dispatch(cleanPost());
 
     if (author) {
-      loadUserPosts(author.id);
+      dispatch(setPosts(author.id));
     } else {
-      setPosts([]);
+      dispatch(cleanPosts());
     }
-  }, [author]);
+  }, [author, dispatch]);
 
   return (
     <main className="section">
@@ -50,7 +46,7 @@ export const App: React.FC = () => {
           <div className="tile is-parent">
             <div className="tile is-child box is-success">
               <div className="block">
-                <UserSelector value={author} onChange={setAuthor} />
+                <UserSelector value={author} />
               </div>
 
               <div className="block" data-cy="MainContent">
@@ -74,11 +70,7 @@ export const App: React.FC = () => {
                 )}
 
                 {author && loaded && !hasError && posts.length > 0 && (
-                  <PostsList
-                    posts={posts}
-                    selectedPostId={selectedPost?.id}
-                    onPostSelected={setSelectedPost}
-                  />
+                  <PostsList posts={posts} selectedPostId={selectedPost?.id} />
                 )}
               </div>
             </div>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,11 +1,30 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
+import {
+  configureStore,
+  ThunkAction,
+  Action,
+  combineReducers,
+} from '@reduxjs/toolkit';
 // eslint-disable-next-line import/no-cycle
-import counterReducer from '../features/counter/counterSlice';
+// import counterReducer from '../features/counter/counterSlice';
+
+import { usersSlice } from '../features/users';
+import { userSlice } from '../features/user';
+import { postsSlice } from '../features/posts';
+import { selectedPostSlice } from '../features/selectedPost';
+import { commentsSlice } from '../features/comments';
+import { NewCommentFormSlice } from '../features/newComentsForm';
+
+const rootReducr = combineReducers({
+  users: usersSlice.reducer,
+  user: userSlice.reducer,
+  posts: postsSlice.reducer,
+  post: selectedPostSlice.reducer,
+  comments: commentsSlice.reducer,
+  newCommentForm: NewCommentFormSlice.reducer,
+});
 
 export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
-  },
+  reducer: rootReducr,
 });
 
 export type AppDispatch = typeof store.dispatch;

--- a/src/components/NewCommentForm.tsx
+++ b/src/components/NewCommentForm.tsx
@@ -1,13 +1,25 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { CommentData } from '../types/Comment';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '../app/store';
+import {
+  cleanCommentsForm,
+  saveCommentsForm,
+  setCommentsForm,
+} from '../features/newComentsForm';
 
 type Props = {
-  onSubmit: (data: CommentData) => Promise<void>;
+  onSubmit: (data: CommentData) => void;
+  submitting: boolean;
 };
 
-export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
-  const [submitting, setSubmitting] = useState(false);
+export const NewCommentForm: React.FC<Props> = ({ onSubmit, submitting }) => {
+  const { name, email, body } = useSelector(
+    (state: RootState) => state.newCommentForm,
+  );
+
+  const dispatch: AppDispatch = useDispatch();
 
   const [errors, setErrors] = useState({
     name: false,
@@ -15,18 +27,8 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
     body: false,
   });
 
-  const [{ name, email, body }, setValues] = useState({
-    name: '',
-    email: '',
-    body: '',
-  });
-
   const clearForm = () => {
-    setValues({
-      name: '',
-      email: '',
-      body: '',
-    });
+    dispatch(cleanCommentsForm());
 
     setErrors({
       name: false,
@@ -35,13 +37,10 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
     });
   };
 
-  const handleChange = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    const { name: field, value } = event.target;
+  const handleChange = (key: string, value: string) => {
+    dispatch(setCommentsForm({ key, value }));
 
-    setValues(current => ({ ...current, [field]: value }));
-    setErrors(current => ({ ...current, [field]: false }));
+    setErrors(current => ({ ...current, key: false }));
   };
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -57,14 +56,10 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
       return;
     }
 
-    setSubmitting(true);
-
     // it is very easy to forget about `await` keyword
     await onSubmit({ name, email, body });
 
-    // and the spinner will disappear immediately
-    setSubmitting(false);
-    setValues(current => ({ ...current, body: '' }));
+    dispatch(saveCommentsForm());
     // We keep the entered name and email
   };
 
@@ -83,7 +78,7 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
             placeholder="Name Surname"
             className={classNames('input', { 'is-danger': errors.name })}
             value={name}
-            onChange={handleChange}
+            onChange={e => handleChange('name', e.target.value)}
           />
 
           <span className="icon is-small is-left">
@@ -120,7 +115,7 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
             placeholder="email@test.com"
             className={classNames('input', { 'is-danger': errors.email })}
             value={email}
-            onChange={handleChange}
+            onChange={e => handleChange('email', e.target.value)}
           />
 
           <span className="icon is-small is-left">
@@ -156,7 +151,7 @@ export const NewCommentForm: React.FC<Props> = ({ onSubmit }) => {
             placeholder="Type comment here"
             className={classNames('textarea', { 'is-danger': errors.body })}
             value={body}
-            onChange={handleChange}
+            onChange={e => handleChange('body', e.target.value)}
           />
         </div>
 

--- a/src/components/PostDetails.tsx
+++ b/src/components/PostDetails.tsx
@@ -1,35 +1,36 @@
 import React, { useEffect, useState } from 'react';
 import { Loader } from './Loader';
 import { NewCommentForm } from './NewCommentForm';
-
-import * as commentsApi from '../api/comments';
-
 import { Post } from '../types/Post';
-import { Comment, CommentData } from '../types/Comment';
+import { CommentData } from '../types/Comment';
+import { AppDispatch, RootState } from '../app/store';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  addPostComment,
+  deleteCurrentComment,
+  deletePostComment,
+  setPostComments,
+} from '../features/comments';
 
 type Props = {
   post: Post;
 };
 
 export const PostDetails: React.FC<Props> = ({ post }) => {
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [loaded, setLoaded] = useState(false);
-  const [hasError, setError] = useState(false);
+  const dispatch: AppDispatch = useDispatch();
+  const { comments, loaded, hasError, submitting } = useSelector(
+    (state: RootState) => state.comments,
+  );
+
   const [visible, setVisible] = useState(false);
 
   function loadComments() {
-    setLoaded(false);
-    setError(false);
     setVisible(false);
 
-    commentsApi
-      .getPostComments(post.id)
-      .then(setComments) // save the loaded comments
-      .catch(() => setError(true)) // show an error when something went wrong
-      .finally(() => setLoaded(true)); // hide the spinner
+    dispatch(setPostComments(post.id));
   }
 
-  useEffect(loadComments, [post.id]);
+  useEffect(loadComments, [post.id, dispatch]);
 
   // The same useEffect with async/await
   /*
@@ -58,35 +59,12 @@ export const PostDetails: React.FC<Props> = ({ post }) => {
   */
 
   const addComment = async ({ name, email, body }: CommentData) => {
-    try {
-      const newComment = await commentsApi.createComment({
-        name,
-        email,
-        body,
-        postId: post.id,
-      });
-
-      setComments(currentComments => [...currentComments, newComment]);
-
-      // setComments([...comments, newComment]);
-      // works wrong if we wrap `addComment` with `useCallback`
-      // because it takes the `comments` cached during the first render
-      // not the actual ones
-    } catch (error) {
-      // we show an error message in case of any error
-      setError(true);
-    }
+    dispatch(addPostComment({ name, email, body, postId: post.id }));
   };
 
-  const deleteComment = async (commentId: number) => {
-    // we delete the comment immediately so as
-    // not to make the user wait long for the actual deletion
-    // eslint-disable-next-line max-len
-    setComments(currentComments =>
-      currentComments.filter(comment => comment.id !== commentId),
-    );
-
-    await commentsApi.deleteComment(commentId);
+  const deleteComment = (commentId: number) => {
+    dispatch(deleteCurrentComment(commentId));
+    dispatch(deletePostComment(commentId));
   };
 
   return (
@@ -158,7 +136,7 @@ export const PostDetails: React.FC<Props> = ({ post }) => {
         )}
 
         {loaded && !hasError && visible && (
-          <NewCommentForm onSubmit={addComment} />
+          <NewCommentForm onSubmit={addComment} submitting={submitting} />
         )}
       </div>
     </div>

--- a/src/components/PostsList.tsx
+++ b/src/components/PostsList.tsx
@@ -3,52 +3,54 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Post } from '../types/Post';
+import { getPost } from '../features/selectedPost';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '../app/store';
 
 type Props = {
   posts: Post[];
   selectedPostId?: number;
-  onPostSelected: (post: Post | null) => void;
 };
 
-export const PostsList: React.FC<Props> = ({
-  posts,
-  selectedPostId = 0,
-  onPostSelected,
-}) => (
-  <div data-cy="PostsList">
-    <p className="title">Posts:</p>
+export const PostsList: React.FC<Props> = ({ posts, selectedPostId = 0 }) => {
+  const dispatch: AppDispatch = useDispatch();
 
-    <table className="table is-fullwidth is-striped is-hoverable is-narrow">
-      <thead>
-        <tr className="has-background-link-light">
-          <th>#</th>
-          <th>Title</th>
-          <th> </th>
-        </tr>
-      </thead>
+  return (
+    <div data-cy="PostsList">
+      <p className="title">Posts:</p>
 
-      <tbody>
-        {posts.map(post => (
-          <tr key={post.id} data-cy="Post">
-            <td data-cy="PostId">{post.id}</td>
-            <td data-cy="PostTitle">{post.title}</td>
-            <td className="has-text-right is-vcentered">
-              <button
-                type="button"
-                data-cy="PostButton"
-                className={classNames('button', 'is-link', {
-                  'is-light': post.id !== selectedPostId,
-                })}
-                onClick={() => {
-                  onPostSelected(post.id === selectedPostId ? null : post);
-                }}
-              >
-                {post.id === selectedPostId ? 'Close' : 'Open'}
-              </button>
-            </td>
+      <table className="table is-fullwidth is-striped is-hoverable is-narrow">
+        <thead>
+          <tr className="has-background-link-light">
+            <th>#</th>
+            <th>Title</th>
+            <th> </th>
           </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
+        </thead>
+
+        <tbody>
+          {posts.map(post => (
+            <tr key={post.id} data-cy="Post">
+              <td data-cy="PostId">{post.id}</td>
+              <td data-cy="PostTitle">{post.title}</td>
+              <td className="has-text-right is-vcentered">
+                <button
+                  type="button"
+                  data-cy="PostButton"
+                  className={classNames('button', 'is-link', {
+                    'is-light': post.id !== selectedPostId,
+                  })}
+                  onClick={() => {
+                    dispatch(getPost(post));
+                  }}
+                >
+                  {post.id === selectedPostId ? 'Close' : 'Open'}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -1,24 +1,28 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { UserContext } from './UsersContext';
 import { User } from '../types/User';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchUsers } from '../features/users';
+import { AppDispatch, RootState } from '../app/store';
+import { getSelectedUser } from '../features/user';
 
 type Props = {
   value: User | null;
-  onChange: (user: User) => void;
 };
 
 export const UserSelector: React.FC<Props> = ({
   // `value` and `onChange` are traditional names for the form field
   // `selectedUser` represents what actually stored here
   value: selectedUser,
-  onChange,
 }) => {
   // `users` are loaded from the API, so for the performance reasons
   // we load them once in the `UsersContext` when the `App` is opened
   // and now we can easily reuse the `UserSelector` in any form
-  const users = useContext(UserContext);
+  // const users = useContext(UserContext);
   const [expanded, setExpanded] = useState(false);
+  const dispatch: AppDispatch = useDispatch();
+
+  const { users } = useSelector((state: RootState) => state.users);
 
   useEffect(() => {
     if (!expanded) {
@@ -41,6 +45,10 @@ export const UserSelector: React.FC<Props> = ({
     // we don't want to listening for outside clicks
     // when the Dopdown is closed
   }, [expanded]);
+
+  useEffect(() => {
+    dispatch(fetchUsers());
+  }, [dispatch]);
 
   return (
     <div
@@ -73,7 +81,7 @@ export const UserSelector: React.FC<Props> = ({
               key={user.id}
               href={`#user-${user.id}`}
               onClick={() => {
-                onChange(user);
+                dispatch(getSelectedUser(user));
               }}
               className={classNames('dropdown-item', {
                 'is-active': user.id === selectedUser?.id,

--- a/src/features/comments.ts
+++ b/src/features/comments.ts
@@ -1,0 +1,131 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createComment, deleteComment, getPostComments } from '../api/comments';
+import { Comment } from '../types/Comment';
+
+export type Init = {
+  loaded: boolean;
+  hasError: boolean;
+  comments: Comment[];
+  submitting: boolean;
+};
+
+const initialState: Init = {
+  loaded: false,
+  hasError: false,
+  comments: [],
+  submitting: false,
+};
+
+export const setPostComments = createAsyncThunk(
+  'fetch/commentsByID',
+  (id: number) => {
+    return getPostComments(id);
+  },
+);
+
+export const addPostComment = createAsyncThunk(
+  'createComment/commentsByID',
+  ({
+    name,
+    email,
+    body,
+    postId,
+  }: {
+    name: string;
+    email: string;
+    body: string;
+    postId: number;
+  }) => {
+    return createComment({
+      name,
+      email,
+      body,
+      postId,
+    });
+  },
+);
+
+export const deletePostComment = createAsyncThunk(
+  'deleteComment/commentsByID',
+  (id: number) => {
+    return deleteComment(id);
+  },
+);
+
+export const commentsSlice = createSlice({
+  name: 'comments',
+  initialState,
+  reducers: {
+    deleteCurrentComment: (state, action: PayloadAction<number>) => {
+      // eslint-disable-next-line no-param-reassign
+      state.comments = state.comments.filter(
+        comment => comment.id !== action.payload,
+      );
+    },
+  },
+  extraReducers(builder) {
+    builder.addCase(setPostComments.pending, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = false;
+      // eslint-disable-next-line no-param-reassign
+      state.loaded = false;
+    });
+
+    builder.addCase(
+      setPostComments.fulfilled,
+      (state, action: PayloadAction<Comment[]>) => {
+        // eslint-disable-next-line no-param-reassign
+        state.comments = action.payload;
+        // eslint-disable-next-line no-param-reassign
+        state.loaded = true;
+      },
+    );
+
+    builder.addCase(setPostComments.rejected, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = true;
+      // eslint-disable-next-line no-param-reassign
+      state.loaded = true;
+    });
+
+    builder.addCase(addPostComment.pending, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.submitting = true;
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = false;
+    });
+
+    builder.addCase(
+      addPostComment.fulfilled,
+      (state, action: PayloadAction<Comment>) => {
+        // eslint-disable-next-line no-param-reassign
+        state.submitting = false;
+        state.comments.push(action.payload);
+      },
+    );
+
+    builder.addCase(addPostComment.rejected, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = true;
+    });
+
+    builder.addCase(deletePostComment.pending, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = false;
+    });
+
+    // builder.addCase(deletePostComment.fulfilled, (state, action) => {
+    //   // eslint-disable-next-line no-param-reassign
+    //   state.comments = state.comments.filter(
+    //     comment => comment.id !== action.payload,
+    //   );
+    // });
+
+    builder.addCase(deletePostComment.rejected, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = true;
+    });
+  },
+});
+
+export const { deleteCurrentComment } = commentsSlice.actions;

--- a/src/features/newComentsForm.ts
+++ b/src/features/newComentsForm.ts
@@ -1,0 +1,45 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface Init {
+  name: string;
+  email: string;
+  body: string;
+}
+
+const initialState: Init = {
+  name: '',
+  email: '',
+  body: '',
+};
+
+export const NewCommentFormSlice = createSlice({
+  name: 'commentsForm',
+  initialState,
+  reducers: {
+    setCommentsForm: (
+      state,
+      action: PayloadAction<{ key: string; value: string }>,
+    ) => {
+      return {
+        ...state,
+        [action.payload.key]: action.payload.value,
+      };
+    },
+    saveCommentsForm: state => {
+      return {
+        ...state,
+        body: '',
+      };
+    },
+    cleanCommentsForm: () => {
+      return {
+        name: '',
+        email: '',
+        body: '',
+      };
+    },
+  },
+});
+
+export const { saveCommentsForm, setCommentsForm, cleanCommentsForm } =
+  NewCommentFormSlice.actions;

--- a/src/features/posts.ts
+++ b/src/features/posts.ts
@@ -1,0 +1,55 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Post } from '../types/Post';
+import { getUserPosts } from '../api/posts';
+
+export type Init = {
+  loaded: boolean;
+  posts: Post[];
+  hasError: boolean;
+};
+
+const initialState: Init = {
+  loaded: false,
+  posts: [],
+  hasError: false,
+};
+
+export const setPosts = createAsyncThunk('fetch/posts', (id: number) => {
+  return getUserPosts(id);
+});
+
+export const postsSlice = createSlice({
+  name: 'posts',
+  initialState,
+  reducers: {
+    cleanPosts: state => {
+      // eslint-disable-next-line no-param-reassign
+      state.posts = [];
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(setPosts.pending, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.loaded = false;
+    });
+
+    builder.addCase(
+      setPosts.fulfilled,
+      (state, action: PayloadAction<Post[]>) => {
+        // eslint-disable-next-line no-param-reassign
+        state.posts = action.payload;
+        // eslint-disable-next-line no-param-reassign
+        state.loaded = true;
+      },
+    );
+
+    builder.addCase(setPosts.rejected, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.loaded = true;
+      // eslint-disable-next-line no-param-reassign
+      state.hasError = true;
+    });
+  },
+});
+
+export const { cleanPosts } = postsSlice.actions;

--- a/src/features/selectedPost.ts
+++ b/src/features/selectedPost.ts
@@ -1,0 +1,23 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Post } from '../types/Post';
+
+const initialState = null as Post | null;
+
+export const selectedPostSlice = createSlice({
+  name: 'post',
+  initialState,
+  reducers: {
+    getPost: (state, acton: PayloadAction<Post>) => {
+      if (state?.id === acton.payload.id) {
+        return null;
+      } else {
+        return acton.payload;
+      }
+    },
+    cleanPost: state => {
+      return null;
+    },
+  },
+});
+
+export const { getPost, cleanPost } = selectedPostSlice.actions;

--- a/src/features/user.ts
+++ b/src/features/user.ts
@@ -1,0 +1,16 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { User } from '../types/User';
+
+const initialState = null as User | null;
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    getSelectedUser: (state, action: PayloadAction<User>) => {
+      return action.payload;
+    },
+  },
+});
+
+export const { getSelectedUser } = userSlice.actions;

--- a/src/features/users.ts
+++ b/src/features/users.ts
@@ -1,0 +1,47 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { User } from '../types/User';
+import { getUsers } from '../api/users';
+
+export type Init = {
+  loading: boolean;
+  users: User[];
+  error: string;
+};
+
+const initialState: Init = {
+  loading: false,
+  users: [],
+  error: '',
+};
+
+export const fetchUsers = createAsyncThunk('fetch/users', () => {
+  return getUsers();
+});
+
+export const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchUsers.pending, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.loading = true;
+    });
+
+    builder.addCase(
+      fetchUsers.fulfilled,
+      (state, action: PayloadAction<User[]>) => {
+        // eslint-disable-next-line no-param-reassign
+        state.users = action.payload;
+
+        // eslint-disable-next-line no-param-reassign
+        state.loading = false;
+      },
+    );
+
+    builder.addCase(fetchUsers.rejected, state => {
+      // eslint-disable-next-line no-param-reassign
+      state.error = 'we have some errors';
+    });
+  },
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,19 +4,15 @@ import { HashRouter as Router } from 'react-router-dom';
 
 import { store } from './app/store';
 import { App } from './App';
-import { UsersProvider } from './components/UsersContext';
 
 const container = document.getElementById('root') as HTMLElement;
 const root = createRoot(container);
 
 const Root = () => (
   <Provider store={store}>
-    {/* Remove UsersProvider when you move users to Redux store */}
-    <UsersProvider>
-      <Router>
-        <App />
-      </Router>
-    </UsersProvider>
+    <Router>
+      <App />
+    </Router>
   </Provider>
 );
 


### PR DESCRIPTION
# React + Redux list of posts

You have the already implemented
[Dynamic list of posts](https://github.com/mate-academy/react_dynamic-list-of-posts#react_dynamic-list-of-posts)
and the `Counter` example of Redux Toolkit usage.

> Here is the [working DEMO](https://mate-academy.github.io/react_redux-list-of-posts/)

Learn the implemented App and the example and reimplement it with Redux having the next slice:
- `users` and remove `UsersContext`;
- `author` that is currently in the `App`;
- `posts` having 3 props `loaded`, `hasError` and `items`;
- `selectedPost`;
- `comments` with `loaded`, `hasError` and `items` props (keep the `visible` in the `PostDetails`);
- `NewCommentForm` should keep its state.